### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,8 +9,4 @@ app.get("/", (req, res) => {
   });
 });
 
-app.listen(port, () => {
-  console.log("Listening on " + port);
-});
-
 module.exports = app;


### PR DESCRIPTION
This pull request removes the server's ability to listen for incoming requests by deleting the `app.listen` call in `server.js`. 

Key change:

* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL12-L15): Removed the `app.listen` method, which was responsible for starting the server and logging the listening port. This change may indicate a shift in how the server is being started or tested.